### PR TITLE
Improve documentation generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,21 +4,26 @@ Documentation for Querqy projects
 The documentation format is reStructuredText. It is built using Sphinx. It will
 be deployed via readthedocs.org. See [here](https://docs.readthedocs.io/en/stable/intro/getting-started-with-sphinx.html) for an introduction to the tool stack.
 
-## Installing dependencies
+## Developing
 
+### Installing dependencies
 ```
-pip3 install sphinx==1.8.5
-pip3 install sphinx_rtd_theme
+pip3 install -r docs/requirements.txt
 ```
+Make sure that Sphinx is installed with the version from the [requirements file](docs/requirements.txt) and, if you had already
+installed an older Sphinx version, that this is the first version in your `PATH`.
 
-Make sure that Sphinx is installed with version 1.8.5 and, if you had already
-installed an older Sphinx version, that this is the first version in your PATH.
-
-## Build
+### Build
 
 Run
-
-`make clean html`
-
-in the `docs` folder. The generated documents will be saved in the `build`
-folder. 
+```
+cd docs
+make clean html
+```
+The generated documents will be saved in the `build` directory.
+You may locally preview the generated documentation by running a local http server in the `build` directory:
+```
+cd docs
+make serve
+```
+This will serve the generated documentation on [http://localhost:8000](http://localhost:8000).

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -12,7 +12,10 @@ BUILDDIR      = build
 help:
 	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 
-.PHONY: help Makefile
+.PHONY: help serve Makefile
+
+serve:
+	@python3 -m http.server --bind 127.0.0.1 --directory build/html
 
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,2 @@
-sphinx>=1.8.5
-sphinx_rtd_theme
+sphinx==3.3.1
+sphinx_rtd_theme==0.5.0


### PR DESCRIPTION
This PR aims to improve on the Sphinx setup by making both local development more convenient and improving the CI resilience:
- Fix the sphinx version during CI build (and match documentation to the
  fixed version)
- Add a convenience make target to locally serve the generated docs

Note:  this pull-request is simply a cherry-pick of the technical commit from my [other pull request](https://github.com/querqy/querqy-docs/pull/7). The other PR has some conflicts in the documentation part. This PR on the other hand should be directly applicable to the master and improve the sphinx setup.