### PR TITLE
Reference to parameters is hidden in nav bar.

### DIFF
--- a/docs/source/querqy/more-about-queries.rst
+++ b/docs/source/querqy/more-about-queries.rst
@@ -110,7 +110,7 @@ are no boost queries on the Querqy query use the query paramer ``querqy.rq={!ltr
 .. _querqy_query_params:
 
 Reference
-=========
+---------
 
 .. include:: se-section.txt
 


### PR DESCRIPTION
Let the Reference content show up in the left hand menu, it appears to be a sub content of the Solr section directly above it, which it is not!


I tried to come up with a better name then _Reference_, like maybe _Query Parameter Reference_ or _Query Syntax Reference_, but didn't really hit on one!